### PR TITLE
Removing the `ref` dependency from Form inputs

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -99,6 +99,13 @@ export default React.createClass({
         onSubmit: PropTypes.func,
         onChange: PropTypes.func,
         children: PropTypes.node
+
+    getDefaultProps() {
+        return {
+            onChange: function() {},
+            onSubmit: function() {}
+        };
+    },
     },
 
     onChange() {

--- a/src/form.js
+++ b/src/form.js
@@ -102,12 +102,9 @@ export default React.createClass({
     },
 
     onChange() {
-        console.log('onChange', this.refs);
-        this.props.onChange();
     },
 
     onSubmit() {
-        console.log('onSubmit');
     },
 
     cloneChildren(children) {

--- a/src/form.js
+++ b/src/form.js
@@ -98,10 +98,7 @@ export default React.createClass({
     propTypes: {
         onSubmit: PropTypes.func,
         onChange: PropTypes.func,
-        children: PropTypes.oneOfType([
-            PropTypes.object,
-            PropTypes.array
-        ])
+        children: PropTypes.node
     },
 
     onChange() {

--- a/src/form.js
+++ b/src/form.js
@@ -140,7 +140,12 @@ export default React.createClass({
     },
 
     render() {
-        return <div {...this.props} onChange={this.onChange} onSubmit={this.onSubmit} ref="form" noValidate={true} onKeyDown={this.onKeyDown}>
+        return <div {...this.props}
+                    ref="form"
+                    onChange={this.onChange}
+                    onSubmit={this.onSubmit}
+                    onKeyDown={this.onKeyDown}
+                    noValidate={true}>
             {this.cloneChildren(this.props.children)}
         </div>;
     }

--- a/src/form.js
+++ b/src/form.js
@@ -105,7 +105,8 @@ export default React.createClass({
     },
 
     onChange() {
-        console.log('onChange');
+        console.log('onChange', this.refs);
+        this.props.onChange();
     },
 
     onSubmit() {
@@ -122,15 +123,19 @@ export default React.createClass({
                 return child;
             }
 
-            if (child.props && child.ref) {
+            if (child.props && child.props.name) {
                 return React.cloneElement(child, {
+                    ref: child.props.name,
                     onChange: this.onChange,
                     onSubmit: this.onSubmit
                 }, child.props && child.props.children);
             } else {
-                return React.cloneElement(child, {}, this.cloneChildren(child.props && child.props.children));
+                return React.cloneElement(
+                    child,
+                    {},
+                    this.cloneChildren(child.props && child.props.children)
+                );
             }
-
         }, this);
     },
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,13 @@ import Form from './form';
 import Input from './inputs/input';
 
 export class App extends React.Component {
+	onChange() {
+		console.log('parent');
+	}
+
 	render() {
-        return <Form>
-			<Input type="text" ref="name" format={x => x.toUpperCase()}/>
+        return <Form onChange={this.onChange.bind(this)}>
+			<Input type="text" name="test" format={x => x.toUpperCase()}/>
         </Form>;
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,8 @@ import Form from './form';
 import Input from './inputs/input';
 
 export class App extends React.Component {
-	onChange() {
-		console.log('parent');
-	}
-
 	render() {
-        return <Form onChange={this.onChange.bind(this)}>
+        return <Form>
 			<Input type="text" name="test" format={x => x.toUpperCase()}/>
         </Form>;
 	}


### PR DESCRIPTION
Before we would require that all inputs need to specify `ref` in order to be serialized. Instead, we will require all form components to have a `name` prop (or something similar). The Form itself will handle refs and whatnot.

One major(?) drawback is that anything with a `name` prop will not be accessible to the parent component via `this.refs`. We will need to have a helper method on the form that can get inputs. This is due to the fact that we are cloning these elements and the parent looses scope. We should document this well. 